### PR TITLE
Windows support example update

### DIFF
--- a/examples/5-eks-cluster-with-windows-support/README.md
+++ b/examples/5-eks-cluster-with-windows-support/README.md
@@ -1,15 +1,67 @@
-# EKS Cluster with Windows Node group  and Linux Spot Node Group
-
-The following steps walks you through the deployment of this example 
+# EKS Cluster with Windows support
 
 This default config deploys the following AWS resources.
  - Creates a new VPC, 3 AZs with private and public subnets
  - Creates necessary VPC endpoints for node groups in private subnets
  - Creates an Internet gateway and a NAT gateway in each public subnet
  - Creates an EKS cluster a managed node group of Linux spot worker nodes and a self-managed node group of Windows on-demand worker nodes
- 
 
-## Deploy sample Windows and Linux deployments to verify support for both operating systems
+The following steps walk you through the deployment of this example.
+
+# How to deploy
+
+## Prerequisites:
+Ensure that you have installed the following tools in your Mac or Windows Laptop before start working with this module and run `terraform plan` and `terraform apply`
+
+1. [aws cli](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+2. [kubectl](https://Kubernetes.io/docs/tasks/tools/)
+3. [terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+
+## Deployment steps
+
+### Step1: Clone the repo using the command below
+
+```shell script
+git clone https://gitlab.aws.dev/vabonthu/terraform-aws-eks-accelerator-patterns.git
+```
+
+### Step2: Run terraform init
+
+to initialize a working directory with configuration files
+
+```shell script
+cd examples/5-eks-cluster-with-windows-support
+terraform init
+```
+
+### Step3: Run terraform plan
+
+to verify the resources created by this execution
+
+```shell script
+export AWS_REGION="us-east-1"   # Select your own region
+terraform plan
+```
+
+### Step4: Run terraform apply
+
+to create resources
+
+```shell script
+terraform apply -auto-approve
+```
+
+## Configure kubectl and test cluster
+
+EKS Cluster details can be extracted from terraform output or from AWS Console to get the name of cluster. This following command used to update the `kubeconfig` in your local machine where you run kubectl commands to interact with your EKS Cluster.
+
+### Step5: Run update-kubeconfig command.
+
+`~/.kube/config` file gets updated with EKS cluster context from the below command. Use the cluster's name available in the Terraform output as `eks_cluster_name`.
+
+    $ aws eks --region us-east-1 update-kubeconfig --name <eks_cluster_name>
+
+### Step6: (Optional) Deploy sample Windows and Linux workloads to verify support for both operating systems
 
 ```shell script
 cd examples/5-eks-cluster-with-windows-support
@@ -29,7 +81,7 @@ kubectl apply -f ./k8s/linux-nginx.yaml
 
 ```shell script
 cd examples/5-eks-cluster-with-windows-support
-# If you deployed sample Windows & Linux deployed from Step6
+# If you deployed sample Windows & Linux workloads from Step6
 kubectl delete svc,deploy -n windows --all
 kubectl delete svc,deploy -n linux --all
 # Destroy all resources

--- a/examples/5-eks-cluster-with-windows-support/k8s/windows-iis-aspnet.yaml
+++ b/examples/5-eks-cluster-with-windows-support/k8s/windows-iis-aspnet.yaml
@@ -49,4 +49,4 @@ spec:
   selector:
     app: aspnet
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP

--- a/examples/5-eks-cluster-with-windows-support/main.tf
+++ b/examples/5-eks-cluster-with-windows-support/main.tf
@@ -22,15 +22,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.66.0"
+      version = "~> 3.66.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.6.1"
+      version = "~> 2.6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.4.1"
+      version = "~> 2.4.0"
     }
   }
 }
@@ -76,7 +76,6 @@ module "aws_vpc" {
   enable_nat_gateway   = true
   create_igw           = true
   enable_dns_hostnames = true
-  single_nat_gateway   = true
 
   public_subnet_tags = {
     "kubernetes.io/cluster/${local.cluster_name}" = "shared"
@@ -93,7 +92,7 @@ module "aws_vpc" {
 # Example to consume aws-eks-accelerator-for-terraform module
 #---------------------------------------------------------------
 module "aws_eks_accelerator" {
-  source = "github.com/aws-samples/aws-eks-accelerator-for-terraform"
+  source = "git@github.com:aws-samples/aws-eks-accelerator-for-terraform.git"
 
   tenant            = local.tenant
   environment       = local.environment
@@ -108,7 +107,12 @@ module "aws_eks_accelerator" {
   create_eks         = true
   kubernetes_version = local.kubernetes_version
 
+  # Ensure AWS VPC CNI is used
+  enable_vpc_cni_addon  = true
+  vpc_cni_addon_version = "v1.10.1-eksbuild.1"
+
   # MANAGED NODE GROUPS
+  enable_managed_nodegroups = true # default false
   managed_node_groups = {
     mng_spot_medium = {
       node_group_name = "mng-spot-med"
@@ -119,6 +123,9 @@ module "aws_eks_accelerator" {
       disk_size       = 30
     }
   }
+
+  # SELF-MANAGED NODE GROUPS
+  enable_self_managed_nodegroups = true # default false
 
   # Enable Windows support
   enable_windows_support = true # default false

--- a/examples/5-eks-cluster-with-windows-support/main.tf
+++ b/examples/5-eks-cluster-with-windows-support/main.tf
@@ -26,11 +26,11 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.6.0"
+      version = "~> 2.6.1"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.4.0"
+      version = "~> 2.4.1"
     }
   }
 }

--- a/examples/5-eks-cluster-with-windows-support/main.tf
+++ b/examples/5-eks-cluster-with-windows-support/main.tf
@@ -112,7 +112,6 @@ module "aws_eks_accelerator" {
   vpc_cni_addon_version = "v1.10.1-eksbuild.1"
 
   # MANAGED NODE GROUPS
-  enable_managed_nodegroups = true # default false
   managed_node_groups = {
     mng_spot_medium = {
       node_group_name = "mng-spot-med"
@@ -125,8 +124,6 @@ module "aws_eks_accelerator" {
   }
 
   # SELF-MANAGED NODE GROUPS
-  enable_self_managed_nodegroups = true # default false
-
   # Enable Windows support
   enable_windows_support = true # default false
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-ia/terraform-ssp-amazon-eks/issues/89

*Description of changes:*
Updated example as needed for the latest version of Windows VPC controller that can be enabled in EKS control plane. This will work after the [corresponding PR](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/pull/85) is merged in the SSP repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
